### PR TITLE
Potential fix for code scanning alert no. 5: Code injection

### DIFF
--- a/.github/workflows/vulnerability-test.yml
+++ b/.github/workflows/vulnerability-test.yml
@@ -9,7 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Vulnerable step
+        env:
+          INPUT: ${{ github.event.comment.body }}
         run: |
-          INPUT="${{ github.event.comment.body }}"
           echo "User input:"
           echo "$INPUT"


### PR DESCRIPTION
Potential fix for [https://github.com/zunalita/discussions/security/code-scanning/5](https://github.com/zunalita/discussions/security/code-scanning/5)

To fix the problem, the untrusted `github.event.comment.body` value should be passed into the step via an environment variable using expression syntax, and then read inside the shell using standard shell variable expansion (`$VAR`), not `${{ ... }}`. This removes GitHub expression interpolation from the `run:` body and prevents code injection via crafted comment bodies.

Concretely, in `.github/workflows/vulnerability-test.yml`, update the vulnerable step to define an environment variable (e.g., `INPUT`) under `env:` with `INPUT: ${{ github.event.comment.body }}`. Then, in the `run:` section, remove the assignment that uses `${{ ... }}` and instead just reference `$INPUT` directly. Functionality remains the same: the workflow still echoes “User input:” followed by the comment body, but the untrusted input no longer participates in GitHub expression parsing inside the script.

No new imports, methods, or external definitions are needed; only the YAML for this step must be adjusted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
